### PR TITLE
Setup script for cuberite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cuberite.tar.gz
+Cuberite

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+rm Cuberite.tar.gz
+wget https://builds.cuberite.org/job/Cuberite%20Linux%20x64%20Master/lastSuccessfulBuild/artifact/Cuberite.tar.gz
+rm -rf Cuberite
+mkdir Cuberite
+tar -x -C Cuberite -f Cuberite.tar.gz


### PR DESCRIPTION
This module provides the `setup.sh` for the cuberite installation. Used
as submodule in the single servers.